### PR TITLE
Build: serialize apps building

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -126,6 +126,7 @@ BIN = libapps$(LIBEXT)
 
 all: $(BIN)
 .PHONY: $(INSTALLED_APPS) context depend clean distclean
+.NOTPARALLEL: $(INSTALLED_APPS)
 
 $(INSTALLED_APPS):
 	$(Q) $(MAKE) -C $@ TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"


### PR DESCRIPTION
With the recent addition of PX4 buils in the new Waf build system in Ardupilot we started seeing some failed buils, for example: https://semaphoreci.com/diydrones/ardupilot/branches/pull-request-3758/builds/5, https://semaphoreci.com/diydrones/ardupilot/branches/pull-request-3750/builds/1 and https://travis-ci.org/ArduPilot/ardupilot/jobs/119014366

They all have one fact in common: they all fail in the link stage, with an _undefined reference to_ an item that should be in the libapps.a static library. After some testing I concluded that, indeed, sometimes items were missing from the libapps.a file.
When using multiple jobs with make, the apps are being built in parallel and that makes the _ar_ program sometimes be run in parallel. I wasn't sure if using _ar_ at the same time with an output to the same file would cause any trouble and I couldn't find any information in Internet, but I tried to reproduce it and I could: I grabbed an object file, copied it 40 times, naming them _fileN.o_ and then run the command `files1=""; files2=""; i=1; while [ $i -le 20 ]; do files2="$files2 file$(($i + 20)).o"; files1="$files1 file$((i++)).o"; done; arm-none-eabi-ar rcs libapp.a $files2 & arm-none-eabi-ar rcs libapp.a $files1`. After running it a number of times I could verify that sometimes all files would be there, sometimes only _files1_ where there and other times only _files2_ where there.

The simple fix is to not allow apps to be built in parallel. This can be done more granularm since only _ar_ can't be run in parallel, but I think that would need more changes and time than its worth.

I gathered some data to prove the fix worked. I ran the command `i=1; while : ; do echo $((i++)); (waf distclean && waf configure --board px4-v4 && waf -j4 plane >../log.txt 2>&1) || break; done`, which builds ArduPlane consecutively until it fails. Before the fix, I ran it 10 consecutive times, each one failed at build number:

- 1
- 4
- 1
- 14
- 5
- 14
- 3
- 1
- 11
- 45

This means that it did 99 builds and failed 10 times, an approximate average of 10 builds to fail. After the fix, it ran 350 times with not one single failure, at which point I stopped it. While I was just testing the fix (before gathering numbers) it also ran 61 times without any failure.