### PR TITLE
Delete meaningless judgment of compile warning.

### DIFF
--- a/nuttx/sched/mq_timedreceive.c
+++ b/nuttx/sched/mq_timedreceive.c
@@ -198,7 +198,7 @@ ssize_t mq_timedreceive(mqd_t mqdes, void *msg, size_t msglen,
       return ERROR;
     }
 
-  if (!abstime || abstime->tv_sec < 0 || abstime->tv_nsec > 1000000000)
+  if (!abstime || abstime->tv_nsec > 1000000000)
     {
       set_errno(EINVAL);
       return ERROR;

--- a/nuttx/sched/mq_timedsend.c
+++ b/nuttx/sched/mq_timedsend.c
@@ -199,7 +199,7 @@ int mq_timedsend(mqd_t mqdes, const char *msg, size_t msglen, int prio,
       return ERROR;
     }
 
-  if (!abstime || abstime->tv_sec < 0 || abstime->tv_nsec > 1000000000)
+  if (!abstime || abstime->tv_nsec > 1000000000)
     {
       set_errno(EINVAL);
       return ERROR;

--- a/nuttx/sched/sem_timedwait.c
+++ b/nuttx/sched/sem_timedwait.c
@@ -223,7 +223,7 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
    * with a valid timeout.
    */
 
-  if (abstime->tv_sec < 0 || abstime->tv_nsec > 1000000000)
+  if (abstime->tv_nsec > 1000000000)
     {
       err = EINVAL;
       goto errout_disabled;


### PR DESCRIPTION
Compilation has been warned. 
The type of tv_sec is uint32_t. 
Therefore it should not be smaller than 0.